### PR TITLE
Add ReusableCard component for displaying wallet information

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,0 +1,9 @@
+import ReusableCard from "@/component/ReusableCard/reusablecard";
+
+export default function Page() {
+  return (
+    <div className='flex justify-center items-center min-h-screen bg-foreground'>
+      <ReusableCard name="TestXXX" walletAddress="abcdxxxx0000" />
+    </div>
+  );
+}

--- a/src/component/ReusableCard/reusablecard.tsx
+++ b/src/component/ReusableCard/reusablecard.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+
+type ReusableCardProps = {
+  
+  name: string;
+  walletAddress: string;
+};
+
+export default function ReusableCard({ name , walletAddress}: ReusableCardProps) {
+  return (
+    <div className='flex justify-center items-center min-h-screen '>
+        <Card sx={{ minWidth: 280, border: '1px solid', borderColor: 'divider', borderRadius:4, padding: 2, boxShadow: 10}}>
+      <CardContent>
+        <Typography gutterBottom sx={{ color: 'text.foreground', fontSize: 18 }}>
+          Wallet Information
+        </Typography>
+        <div className='flex flex-col gap-2'>
+        <Typography variant="h5" component="div">
+            Owner: {name}
+        </Typography>
+        <Typography variant="body2">
+        Wallet Address: {walletAddress}
+          <br />
+        </Typography>
+        </div>
+      </CardContent>
+      <CardActions>
+        <Button size="small">Learn More</Button>
+      </CardActions>
+    </Card>
+    </div>
+  );
+}


### PR DESCRIPTION

<img width="584" height="395" alt="image" src="https://github.com/user-attachments/assets/5faf556f-e81b-4d49-9092-3d2018e84035" />

**Description:**  
This PR introduces a reusable card component to the codebase. The new component is designed for flexibility and can display various content, including owner and wallet address information. It uses Tailwind CSS for styling and supports easy customization for future use cases. This addition improves UI consistency and code reusability across the project.