### PR TITLE
Show WalletConnectButton only in Header component

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,8 +1,21 @@
+"use client";
+import Header from "@/component/Header/Header";
 import ReusableCard from "@/component/ReusableCard/reusablecard";
+import { useState } from "react";
 
 export default function Page() {
+  const [walletAddress, setWalletAddress] = useState<string | undefined>();
+
+  function onConnect(address: string) {
+    setWalletAddress(address);
+  }
   return (
-    <div className='flex justify-center items-center min-h-screen bg-foreground'>
+    <div className="flex justify-center items-center min-h-screen bg-foreground">
+      <Header
+        title="Test Page"
+        walletAddress={walletAddress || ""}
+        onConnect={onConnect}
+      />
       <ReusableCard name="TestXXX" walletAddress="abcdxxxx0000" />
     </div>
   );

--- a/src/component/Button/WalletConnectButton.tsx
+++ b/src/component/Button/WalletConnectButton.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { Button } from "@mui/material";
 import { ethers } from "ethers";
-import { useState } from "react";
-  
+
 import { MetaMaskInpageProvider } from "@metamask/providers";
 
 declare global {
@@ -11,9 +10,15 @@ declare global {
   }
 }
 
-export default function WalletConnectButton() {
-  const [address, setAddress] = useState<string | null>(null);
+type WalletConnectButtonProps = {
+  onConnect?: (address: string) => void;
+  walletAddress?: string;
+};
 
+export default function WalletConnectButton({
+  onConnect,
+  walletAddress,
+}: WalletConnectButtonProps) {
   async function onClickHandler() {
     if (!window.ethereum) {
       alert("Please install Metamask");
@@ -22,7 +27,7 @@ export default function WalletConnectButton() {
     try {
       const provider = new ethers.BrowserProvider(window.ethereum);
       const accounts = await provider.send("eth_requestAccounts", []);
-      setAddress(accounts[0]);
+      if (onConnect) onConnect(accounts[0]);
     } catch (err) {
       console.error("User rejected connection", err);
     }
@@ -31,8 +36,8 @@ export default function WalletConnectButton() {
   return (
     <main className="flex justify-center items-center h-screen">
       <Button variant="outlined" onClick={onClickHandler}>
-        {address
-          ? `${address.slice(0, 6)}...${address.slice(-4)}`
+        {walletAddress
+          ? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}`
           : "Connect Wallet"}
       </Button>
     </main>

--- a/src/component/Header/Header.tsx
+++ b/src/component/Header/Header.tsx
@@ -1,15 +1,18 @@
+import WalletConnectButton from "../Button/WalletConnectButton";
+
 type HeaderProps = {
   title: string;
   walletAddress: string;
+  onConnect?: (address: string) => void;
 };
 
-export default function Header({ title, walletAddress }: HeaderProps) {
+export default function Header({ title, walletAddress, onConnect }: HeaderProps) {
   return (
     <header className="border border-foreground shadow-lg w-full h-24 py-2 rounded-md bg-background text-foreground">
       <nav>
         <ul className="flex flex-col justify-center items-center space-y-3">
           <li className="text-4xl font-bold">Title: {title}</li>
-          <li className="text-lg">Wallet Address: {walletAddress}</li>
+          <li className="text-lg">{walletAddress? `${walletAddress.slice(0, 6)}...${walletAddress.slice(-4)}` : <WalletConnectButton onConnect={onConnect} walletAddress={walletAddress} />}</li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
#17 

**PR Description:**  
This pull request refactors the wallet connection UI so that the `WalletConnectButton` is rendered exclusively within the `Header` component. Previously, the button appeared both in the header and on the main page, resulting in duplicate buttons. Now, the wallet connect logic and button are centralized in the header, improving user experience and code clarity. Unused imports and props have been cleaned up accordingly.