### PR TITLE
Configure wagmi to persist wallet connection across reloads (session persistence feature)

### DIFF
--- a/src/app/Web3Provider.tsx
+++ b/src/app/Web3Provider.tsx
@@ -4,16 +4,17 @@ import { mainnet, polygon } from "wagmi/chains";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactNode } from "react";
 
-// get api key from .env file
 const INFURA_API_KEY = process.env.NEXT_PUBLIC_INFURA_API_KEY;
 
 const config = createConfig({
+  autoConnect: true,
   chains: [mainnet, polygon],
   transports: {
     [mainnet.id]: http(`https://mainnet.infura.io/v3/${INFURA_API_KEY}`),
     [polygon.id]: http("https://polygon-rpc.com"),
   },
 });
+
 
 const queryClient = new QueryClient();
 


### PR DESCRIPTION
#19  
Implements wagmi config with autoConnect: true to meet session persistence requirements. Wallet remains connected and address visible after browser or app reload. No reconnect required after refresh, as per acceptance criteria