### PR TITLE
Implement Edit Transaction Toast Notifications for Improved User Feedback

### DIFF
--- a/src/component/TransactionTable/transactiontable.tsx
+++ b/src/component/TransactionTable/transactiontable.tsx
@@ -10,6 +10,7 @@ import { MoreHorizontal, MoreVertical } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useAccount } from "wagmi";
 import TransactionForm from "../TransactionForm/TransactionForm";
+import Snackbar from "@mui/material/Snackbar";
 
 type TransactionTypeProps = "INCOME" | "EXPENSE";
 
@@ -29,6 +30,8 @@ export default function TransactionTable() {
   const [transaction, setTransaction] = useState<TransactionProps[]>([]);
   const [isMounted, setIsMounted] = useState(false);
   const [editingTx, setEditingTx] = useState<TransactionProps | null>(null);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
 
   useEffect(() => {
     setIsMounted(true);
@@ -144,18 +147,32 @@ export default function TransactionTable() {
             <TransactionForm
               transaction={editingTx}
               onClose={() => setEditingTx(null)}
-              onSubmit={(updatedTx) => {
-                setTransaction((prev) =>
-                  prev.map((tx) =>
-                    tx.id === editingTx.id ? { ...tx, ...updatedTx } : tx
-                  )
-                );
-                setEditingTx(null);
+              onSubmit={async (updatedTx) => {
+                try {
+                  setTransaction((prev) =>
+                    prev.map((tx) =>
+                      tx.id === editingTx.id ? { ...tx, ...updatedTx } : tx
+                    )
+                  );
+                  setEditingTx(null);
+                  setSnackbarMessage("Transaction edited successfully!");
+                  setSnackbarOpen(true);
+                } catch (error) {
+                  setSnackbarMessage("Failed to edit transaction.");
+                  setSnackbarOpen(true);
+                }
               }}
             />
           </div>
         </div>
       )}
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackbarOpen(false)}
+        message={snackbarMessage}
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      />
     </>
   );
 }

--- a/src/component/TransactionTable/transactiontable.tsx
+++ b/src/component/TransactionTable/transactiontable.tsx
@@ -41,7 +41,9 @@ export default function TransactionTable() {
       try {
         const res = await fetch(`/api/transactions?address=${address}`);
         const data = await res.json();
-        setTransaction(data.transactions);
+        setTransaction(
+          Array.isArray(data.transactions) ? data.transactions : []
+        );
       } catch (error) {
         setTransaction([]);
       }
@@ -53,96 +55,102 @@ export default function TransactionTable() {
 
   return (
     <>
-      <div className="w-full my-2 max-w-4xl mx-auto mt-16">
-        <table className="w-full table-fixed border border-gray-200 rounded-lg bg-background">
-          <thead className="bg-gray-100">
-            <tr>
-              <th className="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/4">
-                Date
-              </th>
-              <th className="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/4">
-                Description
-              </th>
-              <th className="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/4">
-                Amount
-              </th>
-              <th className="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-1/4">
-                Category
-              </th>
-              <th className="px-4 py-2 text-center text-sm font-semibold text-gray-700 w-12"></th>
-            </tr>
-          </thead>
-          <tbody>
-            {transaction.length === 0 ? (
+      <div className="w-full my-2 max-w-4xl mx-auto mt-16 sm:mx-4">
+        <div className="overflow-x-auto rounded-lg shadow">
+          <table className="min-w-full bg-white border border-gray-200 rounded-lg">
+            <thead className="bg-gray-100">
               <tr>
-                <td
-                  colSpan={5}
-                  className="px-4 py-2 border-t border-gray-200 text-gray-500 text-center"
-                >
-                  No transactions found.
-                </td>
+                <th className="px-4 py-3 text-left text-xs font-bold text-gray-700 uppercase whitespace-nowrap">
+                  Date
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-bold text-gray-700 uppercase whitespace-nowrap">
+                  Description
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-bold text-gray-700 uppercase whitespace-nowrap">
+                  Amount
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-bold text-gray-700 uppercase whitespace-nowrap hidden sm:table-cell">
+                  Category
+                </th>
+                <th className="px-4 py-3 text-center text-xs font-bold text-gray-700 uppercase whitespace-nowrap">
+                  Actions
+                </th>
               </tr>
-            ) : (
-              transaction.map((tx) => (
-                <tr key={tx.id}>
-                  <td className="px-4 py-2 border-t border-gray-200 text-gray-500 text-center">
-                    {tx.date.slice(0, 10)}
-                  </td>
-                  <td className="px-4 py-2 border-t border-gray-200 text-gray-500 text-center">
-                    {tx.description}
-                  </td>
-                  <td className="px-4 py-2 border-t border-gray-200 text-gray-500 text-center">
-                    {tx.amount}
-                  </td>
-                  <td className="px-4 py-2 border-t border-gray-200 text-gray-500 text-center">
-                    {tx.category}
-                  </td>
-                  <td className="text-center border-t border-gray-200">
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <button className="mx-auto flex items-center justify-center p-2 hover:bg-gray-100 rounded-full">
-                          <MoreVertical className="cursor-pointer text-gray-600" />
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => setEditingTx(tx)}>
-                          Edit
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          className="text-red-600 hover:bg-destructive hover:text-background"
-                          onClick={() => alert(`Delete ${tx.id}`)}
-                        >
-                          Delete
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+            </thead>
+            <tbody>
+              {(Array.isArray(transaction) ? transaction.length : 0) === 0 ? (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="px-4 py-6 text-center text-gray-500"
+                  >
+                    No transactions found.
                   </td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
+              ) : (
+                transaction.map((tx, idx) => (
+                  <tr
+                    key={tx.id}
+                    className={idx % 2 === 0 ? "bg-white" : "bg-gray-50"}
+                  >
+                    <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">
+                      {tx.date.slice(0, 10)}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap max-w-xs truncate">
+                      {tx.description}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap">
+                      {tx.amount}
+                    </td>
+                    <td className="px-4 py-3 text-sm text-gray-700 whitespace-nowrap hidden sm:table-cell">
+                      {tx.category}
+                    </td>
+                    <td className="px-4 py-3 text-center whitespace-nowrap">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <button className="mx-auto flex items-center justify-center p-2 hover:bg-gray-100 rounded-full">
+                            <MoreVertical className="cursor-pointer text-gray-600" />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => setEditingTx(tx)}>
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            className="text-red-600 hover:bg-destructive hover:text-background"
+                            onClick={() => alert(`Delete ${tx.id}`)}
+                          >
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
       {editingTx && (
         <div
-          className="fixed inset-0 flex items-center justify-center bg-black/50"
+          className="fixed inset-0 flex items-center justify-center bg-black/50 z-50"
           onClick={() => setEditingTx(null)}
         >
           <div
-            className="rounded-lg max-w-md w-full"
+            className="rounded-lg max-w-md w-full bg-white p-6"
             onClick={(e) => e.stopPropagation()}
           >
             <TransactionForm
               transaction={editingTx}
               onClose={() => setEditingTx(null)}
               onSubmit={(updatedTx) => {
-                // Update the transaction array locally
                 setTransaction((prev) =>
                   prev.map((tx) =>
                     tx.id === editingTx.id ? { ...tx, ...updatedTx } : tx
                   )
                 );
-                setEditingTx(null); // close modal
+                setEditingTx(null);
               }}
             />
           </div>


### PR DESCRIPTION

<img width="682" height="311" alt="image" src="https://github.com/user-attachments/assets/06d050fb-a7a8-461c-ba24-af40528c75c9" />
<img width="682" height="311" alt="image" src="https://github.com/user-attachments/assets/77d426c9-8e13-4095-97a8-bdf5769d110a" />

**Description:**  
This PR introduces MUI Snackbar notifications for transaction edit operations in the transaction table.  
- Displays a success toast when a transaction is edited.
- Displays an error toast if the edit operation fails.
- Toast notifications are non-intrusive and automatically disappear after a few seconds.
This improves user feedback and aligns with UI best practices for CRUD actions.