### PR TITLE
Add dynamic wallet address rendering to ReusableCard using wagmi

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,11 +6,14 @@ import ReusableCard from "@/component/ReusableCard/reusablecard";
 import TransactionForm from "@/component/TransactionForm/TransactionForm";
 import TransactionTable from "@/component/TransactionTable/transactiontable";
 import dynamic from "next/dynamic";
+import { useAccount } from "wagmi";
 
 const LineChart = dynamic(() => import("@/component/Charts/linechart"), { ssr: false });
 const PieChart = dynamic(() => import("@/component/Charts/piechart"), { ssr: false });
 
 export default function Page() {
+  const { address, isConnected } = useAccount(); 
+
   return (
     <ProtectedRoute>
       <main className="bg-foreground min-h-screen">
@@ -18,7 +21,7 @@ export default function Page() {
         <Navbar />
         <TransactionForm />
         <TransactionTable />
-        {/* CHART FLEX CONTAINER */}
+        
         <div className="chart-row">
           <div className="chart-card chart-line">
             <LineChart />
@@ -27,9 +30,11 @@ export default function Page() {
             <PieChart />
           </div>
         </div>
-        
-        <ReusableCard name="Abdul Karim" walletAddress="0xabcd1234ef567890" />
-        
+
+        <ReusableCard 
+          name={isConnected ? "Wallet Owner" : "No Wallet Connected"} 
+          walletAddress={isConnected && address ? address : "0x000...000"} 
+        />
       </main>
     </ProtectedRoute>
   );


### PR DESCRIPTION
- Updated the ReusableCard component to receive and display the connected wallet address dynamically based on wagmi's useAccount hook.
- Modified page.tsx to pass the wallet information as props, instead of using hardcoded values.
- Ensured Card auto-updates on wallet connect/disconnect events for a smoother user experience.
- No breaking changes; static fallback values are shown if wallet is not connected.
