### PR TITLE
Fix API User Creation to Store Wallet Address from Request Body

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -27,7 +27,7 @@ export async function POST(req: Request) {
       return NextResponse.json(
         {
           success: false,
-error: "Wallet address is required",
+          error: "Wallet address is required",
           status: 400,
         },
         { status: 400 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,18 +2,42 @@
 import Header from "@/component/Header/Header";
 import { useAccount } from "wagmi";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function LoginPage() {
-  const {isConnected } = useAccount();
+  const { isConnected, address } = useAccount();
   const router = useRouter();
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     if (isConnected) {
       router.replace("/"); // Connected user will be redirected to the main page
     }
-  }, [isConnected, router]);
+    const fetchAddress = async () => {
+      try {
+        const res = await fetch("/api/users", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ wallet_address: address }),
+        });
+        if (!res.ok) {
+          setError("Failed to send address");
+        } else {
+          setError(null);
+        }
+      } catch (err) {
+        console.error(err);
+        setError("Network Error");
+      }
+    };
+    if (address) {
+      fetchAddress();
+    }
+  }, [isConnected, router, address]);
 
+  if (error) {
+    return <div className="text-destructive">{error}</div>;
+  }
   return (
     <div className="flex flex-col items-center justify-center min-h-screen bg-gray-50 dark:bg-gray-950">
       {/* Header: auto modal trigger */}

--- a/src/libs/auth/users/user.ts
+++ b/src/libs/auth/users/user.ts
@@ -23,6 +23,8 @@ export async function userinfo() {
     };
 }
 
+
+//User Creation(Prisma)
 export async function createUser({wallet_address}: {wallet_address: string}){
  
   const user = await prisma.user.upsert({


### PR DESCRIPTION

<img width="780" height="194" alt="image" src="https://github.com/user-attachments/assets/c8b39e38-fe8c-422d-b241-27e8e9cb098c" />



**Description:**  
This PR updates the user login and creation flow to ensure the wallet address is correctly stored in the database:

- The frontend now sends the wallet address in the request body as `wallet_address`.
- The `/api/users` POST endpoint reads `wallet_address` from the request body instead of URL parameters.
- The backend uses Prisma's `upsert` to create or update the user record based on the wallet address.
- This change ensures that user wallet addresses are reliably recorded upon login.